### PR TITLE
add an input argument to specify whether to run 'rustup self update'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   override:
     description: Set installed toolchain as an override for a directory
     default: false
+  self_update:
+    description: Update rustup itself at first
+    default: false
 
 runs:
   using: 'node12'

--- a/src/args.ts
+++ b/src/args.ts
@@ -30,7 +30,8 @@ export interface ToolchainOptions {
     name: string,
     target?: string,
     default: boolean,
-    override: boolean
+    override: boolean,
+    self_update: boolean,
 }
 
 export function toolchain_args(): ToolchainOptions {
@@ -38,6 +39,7 @@ export function toolchain_args(): ToolchainOptions {
         name: getInput('toolchain', {required: true}),
         target: getInput('target') || undefined,
         default: inputBoolean('default'),
-        override: inputBoolean('override')
+        override: inputBoolean('override'),
+        self_update: inputBoolean('self_update'),
     };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,10 @@ async function run() {
     const opts = args.toolchain_args();
     const rustup = await get_rustup(opts.name);
 
+    if (opts.self_update) {
+        await exec.exec(rustup, ['self', 'update']);
+    }
+
     await exec.exec(rustup, ['toolchain', 'install', opts.name]);
 
     if (opts.default) {


### PR DESCRIPTION
It avoids errors that occur when the older rustup is installed.