### PR TITLE
add profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [additional recipes here](https://github.com/actions-rs/meta).
 | `target`    |          | Additionally install specified target for this toolchain, ex. `x86_64-apple-darwin`                                                    | string |         |
 | `default`   |          | Set installed toolchain as a default toolchain                                                                                         | bool   | false   |
 | `override`  |          | Set installed toolchain as an override for the current directory                                                                       | bool   | false   |
+| `profile`   |          | Profile to specify components to install, ex. `minimal`, `default`, `complete`                                                         | string |         |
 
 ## Components
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   override:
     description: Set installed toolchain as an override for a directory
     default: false
+  profile:
+    description: Profile to install for this toolchain
+    required: false
 
 runs:
   using: 'node12'

--- a/src/args.ts
+++ b/src/args.ts
@@ -30,7 +30,8 @@ export interface ToolchainOptions {
     name: string,
     target?: string,
     default: boolean,
-    override: boolean
+    override: boolean,
+    profile?: string,
 }
 
 export function toolchain_args(): ToolchainOptions {
@@ -38,6 +39,7 @@ export function toolchain_args(): ToolchainOptions {
         name: getInput('toolchain', {required: true}),
         target: getInput('target') || undefined,
         default: inputBoolean('default'),
-        override: inputBoolean('override')
+        override: inputBoolean('override'),
+        profile: getInput('profile') || undefined,
     };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ function downloadRustInit(url: string, name: string): Promise<string> {
     });
 }
 
-async function get_rustup(toolchain: string): Promise<string> {
+async function get_rustup(toolchain: string, profile: string): Promise<string> {
     try {
         const foundPath = await io.which('rustup', true);
         core.debug(`Found rustup at ${foundPath}`);
@@ -45,6 +45,8 @@ async function get_rustup(toolchain: string): Promise<string> {
         '-y',
         '--default-toolchain',
         toolchain,
+        '--profile',
+        profile,
     ];
 
     // Note: `target` input can't be used here for `--default-host` argument, see #8
@@ -72,7 +74,12 @@ async function get_rustup(toolchain: string): Promise<string> {
 
 async function run() {
     const opts = args.toolchain_args();
-    const rustup = await get_rustup(opts.name);
+    const profile = opts.profile ? opts.profile : 'default';
+    const rustup = await get_rustup(opts.name, profile);
+
+    if (opts.profile) {
+        await exec.exec(rustup, ['set', 'profile', opts.profile]);
+    }
 
     await exec.exec(rustup, ['toolchain', 'install', opts.name]);
 


### PR DESCRIPTION
It adds a new input `profile` to specify the profile to be installed, [introduced in rustup 1.20.0](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles).
It helps to reduce the total time for installing components in the toolchain.

fixes #3. 