### PR TITLE
Fix ts file identification in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,7 +6,7 @@
 # This script can yield false positives in cases where you only make stylistic changes to the TypeScript code that don't result in changes to the compiled JavaScript code.
 # It is your responsibility as a developer to then commit the changes with `git commit --no-verify` and simply skip this commit hook.
 
-TS_FILES=$(git diff --staged --name-only | grep -c '.ts')
+TS_FILES=$(git diff --staged --name-only | grep -c '\.ts$')
 DIST_MODIFIED=$(git diff --staged --name-only | grep -c dist/index.js)
 
 if [ $TS_FILES -gt 0 ] && [ $DIST_MODIFIED -eq 0 ] ; then


### PR DESCRIPTION
I have a <code>scrip<b><i>ts</i></b>/⋯.sh</code> file in a fork that was incorrectly causing this hook to be triggered.