### PR TITLE
Fix typo in 'rustc-hash'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Installed `rustc`, `cargo` and `rustup` versions can be fetched from the Action 
 | `cargo`      | Cargo version         | `1.40.0 (bc8e4c8be 2019-11-22)` |
 | `rustup`     | rustup version        | `1.21.1 (7832b2ebe 2019-12-20)` |
 
-Note: `rustc-hash` output value can be used with [actions/cache](https://github.com/actions/cache) Action
+Note: `rustc_hash` output value can be used with [actions/cache](https://github.com/actions/cache) Action
 to store cache for different Rust versions, as it is unique across different Rust versions and builds (including `nightly`).
 
 ## Profiles


### PR DESCRIPTION
This PR changes `rustc-hash` to `rustc_hash` in README.
The output variable name was changed in `1.0.5` but not updated in this place.