### PR TITLE
Support multiple targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-07-19
+
+### Added
+
+- `targets` input now takes a comma-separated list of targets rather than a single target
+
+### Changed
+
+- `target` input is now an alias for `targets`
+
 ## [1.0.6] - 2020-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [additional recipes here](https://github.com/actions-rs/meta).
 | Name         | Required | Description                                                                                                                                         | Type   | Default |
 | ------------ | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------| ------ | --------|
 | `toolchain`  |          | [Toolchain](https://github.com/rust-lang/rustup.rs#toolchain-specification) name to use, ex. `stable`, `nightly`, `nightly-2019-04-20`, or `1.32.0` | string | stable  |
-| `target`     |          | Additionally install specified target for this toolchain, ex. `x86_64-apple-darwin`                                                                 | string |         |
+| `targets`    |          | Comma-separated list of additional targets to install for this toolchain, ex. `x86_64-apple-darwin`                                                 | string |         |
 | `default`    |          | Set installed toolchain as a default toolchain                                                                                                      | bool   | false   |
 | `override`   |          | Set installed toolchain as an override for the current directory                                                                                    | bool   | false   |
 | `profile`    |          | Execute `rustup set profile {value}` before installing the toolchain, ex. `minimal`                                                                 | string | default |

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   targets:
     description: Comma-separated list of additional target triples to install for this toolchain
     required: false
-  targets:
+  target:
     description: Alias for `targets`
     required: false
   default:

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,11 @@ inputs:
 
       If this is not given, the action will try and install the version specified in the `rust-toolchain` file.
     required: false
-  target:
-    description: Target triple to install for this toolchain
+  targets:
+    description: Comma-separated list of additional target triples to install for this toolchain
+    required: false
+  targets:
+    description: Alias for `targets`
     required: false
   default:
     description: Set installed toolchain as default

--- a/src/args.ts
+++ b/src/args.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from "fs";
 
 export interface ToolchainOptions {
     name: string;
-    target: string | undefined;
+    targets: string | undefined;
     default: boolean;
     override: boolean;
     profile: string | undefined;
@@ -41,9 +41,14 @@ export function getToolchainArgs(overrideFile: string): ToolchainOptions {
         components = undefined;
     }
 
+    let targets: string[] | undefined = input.getInputList("targets") || input.getInputList("target");
+    if (targets && targets.length === 0) {
+        targets = undefined;
+    }
+
     return {
         name: determineToolchain(overrideFile),
-        target: input.getInput("target") || undefined,
+        targets: targets,
         default: input.getInputBool("default"),
         override: input.getInputBool("override"),
         profile: input.getInput("profile") || undefined,

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,8 +79,10 @@ async function run(): Promise<void> {
 
     await rustup.installToolchain(opts.name, installOptions);
 
-    if (opts.target) {
-        await rustup.addTarget(opts.target, opts.name);
+    if (opts.targets) {
+        for (const target of opts.targets) {
+            await rustup.addTarget(target, opts.name);
+        }
     }
 
     await versions.gatherInstalledVersions();


### PR DESCRIPTION
This PR renames the `target` input to `targets` (but still supports `target` as an alias) and allows listing multiple targets in a comma-separated list.