### PR TITLE
Update the action to run on Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ outputs:
     description: Installed rustup version
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 is deprecated per https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Fix #219 