### PR TITLE
Update action to use Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ outputs:
     description: Installed rustup version
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
It seems that the Node.js 12 support has been deprecated, making at the moment Github Actions to emit some warnings about such an update.